### PR TITLE
Small PoC for JPG exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 Node module for exporting Draw.io diagrams to a range of formats using Puppeteer, designed as a drop-in replacement for the Draw.io desktop CLI.
 
 ---
+
+## Hacking
+
+We use [`asdf-vm`](https://asdf-vm.com/) with the [`nodejs`](https://github.com/asdf-vm/asdf-nodejs) and [`yarn`](https://github.com/twuni/asdf-yarn) plugins to manage our tool versions. Complete the setup for `asdf-vm` first, or make sure you have compatible equivalents installed.
+
+After cloning, make sure you get the vendored dependencies:
+
+```console
+git submodule update --init
+```

--- a/app.js
+++ b/app.js
@@ -1,0 +1,37 @@
+const fs = require('fs').promises;
+
+require('console-inject');
+const arg = require('arg');
+const exportDiagram = require('./index');
+
+// Options are modelled after the Draw.io Desktop CLI; ideally we should be a
+// 1:1 substitute.
+const args = arg({
+  // Input filename
+  '--export': String,
+  '-x': '--export',
+
+  // Output filename
+  '--output': String,
+  '-o': '--output',
+
+  // Page index (from 0); defaults to 0
+  '--page-index': Number,
+  '-p': '--page-index',
+
+  // Diagram format; defaults to "pdf"
+  '--format': String,
+  '-f': '--format',
+});
+
+function handleRejection(action) {
+  return function(e) {
+    console.error(`${action} failed with`, e);
+  };
+}
+
+fs.readFile(args['--export'], 'utf-8')
+  .catch(handleRejection('reading input'))
+  .then(input => exportDiagram(input, args['--page-index'], args['--format']))
+  .catch(handleRejection('exporting'))
+  .then(result => fs.writeFile(args['--output'], result));

--- a/app.js
+++ b/app.js
@@ -6,23 +6,32 @@ const exportDiagram = require('./index');
 
 // Options are modelled after the Draw.io Desktop CLI; ideally we should be a
 // 1:1 substitute.
-const args = arg({
-  // Input filename
-  '--export': String,
-  '-x': '--export',
-
-  // Output filename
-  '--output': String,
-  '-o': '--output',
-
-  // Page index (from 0); defaults to 0
-  '--page-index': Number,
-  '-p': '--page-index',
-
-  // Diagram format; defaults to "pdf"
-  '--format': String,
-  '-f': '--format',
-});
+const ARG_SPEC = {
+  'input': {
+    'long': '--export',
+    'short': '-x',
+    'type': String,
+    'description': 'Input filename',
+  },
+  'pageIndex': {
+    'long': '--page-index',
+    'short': '-p',
+    'type': Number,
+    'description': 'Page index (from 0); defaults to 0',
+  },
+  'output': {
+    'long': '--output',
+    'short': '-o',
+    'type': String,
+    'description': 'Output filename',
+  },
+  'format': {
+    'long': '--format',
+    'short': '-f',
+    'type': String,
+    'description': 'Diagram format; defaults to "pdf"',
+  },
+};
 
 function handleRejection(action) {
   return function(e) {
@@ -30,8 +39,56 @@ function handleRejection(action) {
   };
 }
 
-fs.readFile(args['--export'], 'utf-8')
-  .catch(handleRejection('reading input'))
-  .then(input => exportDiagram(input, args['--page-index'], args['--format']))
-  .catch(handleRejection('exporting'))
-  .then(result => fs.writeFile(args['--output'], result));
+function parseArgs(argSpec) {
+  const args = {};
+  Object.values(argSpec).forEach(arg => {
+    args[arg.long] = arg.type;
+    args[arg.short] = arg.long;
+  });
+
+  const values = arg(args);
+
+  const result = {};
+  for (const [name, arg] of Object.entries(argSpec)) {
+    if (!(arg.long in values)) {
+      const e = new Error(`Missing required option: ${arg.long}`);
+      e.code = 'ARG_MISSING_REQUIRED';
+      throw e;
+    }
+
+    result[name] = values[arg.long];
+  }
+  return result;
+}
+
+function generateHelp(argSpec) {
+  const lines = [
+    'exporter [options]',
+    '',
+    'Options:',
+  ];
+
+  for (const [name, arg] of Object.entries(argSpec)) {
+    lines.push(`  ${arg.short}, ${arg.long} <${name} (${arg.type.name})>    ${arg.description}`);
+  }
+
+  return lines.join("\n");
+}
+
+try {
+  const {input, pageIndex, output, format} = parseArgs(ARG_SPEC);
+
+  fs.readFile(input, 'utf-8')
+    .catch(handleRejection('reading input'))
+    .then(input => exportDiagram(input, pageIndex, format))
+    .catch(handleRejection('exporting'))
+    .then(result => fs.writeFile(output, result));
+} catch (e) {
+  if (['ARG_UNKNOWN_OPTION', 'ARG_MISSING_REQUIRED'].includes(e.code)) {
+    console.error(e.message);
+    process.stderr.write(generateHelp(ARG_SPEC));
+    process.exit(1);
+  } else {
+    throw e;
+  }
+}

--- a/export.html
+++ b/export.html
@@ -1,0 +1,226 @@
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+    <title>Draw.io exporter</title>
+
+    <link rel="stylesheet" href="vendor/drawio/src/main/webapp/mxgraph/css/common.css" charset="UTF-8" type="text/css">
+    <style>
+      body {
+        margin: 0;
+      }
+
+      @media print {
+        span.MathJax_SVG svg {
+          shape-rendering: crispEdges;
+        }
+        table.mxPageSelector {
+          display: none;
+        }
+        hr.mxPageBreak {
+          display: none;
+        }
+      }
+
+      @media screen {
+        table.mxPageSelector {
+          position: fixed;
+          right: 10px;
+          top: 10px;
+          font-family: Arial;
+          font-size: 10pt;
+          border: solid 1px darkgray;
+          background: white;
+          border-collapse: collapse;
+        }
+        table.mxPageSelector td {
+          border: solid 1px gray;
+          padding: 4px;
+        }
+        body.mxPage {
+          background: gray;
+        }
+      }
+    </style>
+
+    <script>
+      const mxLoadStylesheets = false;
+    </script>
+    <script src="vendor/drawio/src/main/webapp/js/app.min.js"></script>
+    <script>
+      Editor.initMath('vendor/drawio/src/main/webapp/math/MathJax.js');
+
+      // Exposed for Puppeteer
+      function render(input, pageIndex, format) {
+        const TRANSPARENT_COLORS = [
+          '',
+          'none',
+        ];
+        const TRANSPARENT_FORMATS = [
+          'png',
+          'svg',
+        ];
+
+        console.debug('Rendering page', pageIndex, 'of input', input, 'as', format);
+
+        function initializeGraph(body) {
+          console.debug('Initialising empty document');
+          document.body.innerHTML = '';
+          const container = document.createElement('div');
+          container.id = 'graph';
+          container.style.width = '100%';
+          container.style.height = '100%';
+          body.appendChild(container);
+
+          console.debug('Initialising empty graph');
+          const graph = new Graph(container);
+          graph.setEnabled(false);
+          graph.foldingEnabled = false;
+
+          return {container, graph};
+        }
+
+        function monkeypatchGraph(graph) {
+          console.debug('Monkey patching mxGraph to disable custom links');
+
+          const graphGetLinkForCell = graph.getLinkForCell;
+          graph.getLinkForCell = function(cell) {
+            const link = graphGetLinkForCell.apply(this, arguments);
+            if (link != null && this.isCustomLink(link)) {
+              link = null;
+            }
+
+            return link;
+          };
+
+          const cellRendererRedrawLabelShape = graph.cellRenderer.redrawLabelShape;
+          graph.cellRenderer.redrawLabelShape = function(shape) {
+            cellRendererRedrawLabelShape.apply(this, arguments);
+            if (shape.node != null) {
+              const links = shape.node.getElementsByTagName('a');
+
+              for (const i = 0; i < links.length; i++)
+              {
+                const href = links[i].getAttribute('href');
+                if (href != null && graph.isCustomLink(href)) {
+                  links[i].setAttribute('href', '#');
+                }
+              }
+            }
+          };
+
+          // Fits the number of background pages to the graph
+          if (false /* PDF specific */) {
+            graph.view.getBackgroundPageBounds = function() {
+              var layout = this.graph.getPageLayout();
+              var page = this.graph.getPageSize();
+
+              return new mxRectangle(
+                  this.scale * (this.translate.x + layout.x * page.width),
+                  this.scale * (this.translate.y + layout.y * page.height),
+                  this.scale * layout.width * page.width,
+                  this.scale * layout.height * page.height);
+            };
+          }
+        }
+
+        function parseInput(input) {
+          console.debug('Parsing input')
+          const doc = mxUtils.parseXml(input);
+
+          const node = Editor.extractGraphModel(doc.documentElement, true);
+          const xmlDoc = node.ownerDocument;
+
+          if (xmlDoc.documentElement.nodeName !== 'mxfile') {
+            throw new Error(`Unsupported root node name ${xmlDoc.documentElement.nodeName}`);
+          }
+
+          return {node, xmlDoc};
+        }
+
+        function decodeDiagram(graph, xmlDoc) {
+          const codec = new mxCodec(xmlDoc);
+          const model = graph.getModel();
+          codec.decode(xmlDoc.documentElement, model);
+
+          console.debug('decoded graph doc into model', model);
+        }
+
+        function normalizeBackgroundColor(xmlDoc, format) {
+          let backgroundColor = xmlDoc.documentElement.getAttribute('background');
+
+          // Handle some different values that really mean transparent
+          if (TRANSPARENT_COLORS.includes(backgroundColor)) {
+            backgroundColor = null;
+          }
+
+          // Fall back to white for formats that don't support transparency
+          if (!TRANSPARENT_FORMATS.includes(format)) {
+            backgroundColor = '#ffffff';
+          }
+
+          return backgroundColor;
+        }
+
+        function scaleGraph(graph) {
+          const bounds = graph.getGraphBounds();
+          const pageWidth = 800
+          let scale;
+
+          if (bounds.width < pageWidth & bounds.height < 1.5 * pageWidth) {
+            scale = 4;
+          } else if (bounds.width < 2 * pageWidth & bounds.height < 3 * pageWidth) {
+            scale = 3;
+          } else if (bounds.width < 4 * pageWidth && bounds.height < 6 * pageWidth) {
+            scale = 2;
+          }
+
+          graph.view.scaleAndTranslate(scale, Math.floor(bounds.x), Math.floor(bounds.y));
+
+          return {bounds, scale};
+        }
+
+        function renderPage(body, xmlDoc) {
+          const {container, graph} = initializeGraph(body);
+          monkeypatchGraph(graph);
+          decodeDiagram(graph, xmlDoc);
+
+          document.body.style.backgroundColor = normalizeBackgroundColor(xmlDoc, format);
+          const {bounds, scale} = scaleGraph(graph);
+          console.debug('graph reported bounds', bounds, 'and scale', scale);
+          return {bounds, scale};
+        }
+
+        function writeResultInfo(body, pageCount, pageId, bounds, scale) {
+          const indicator = document.createElement('div');
+          indicator.id = 'result-info';
+          indicator.style.display = 'none';
+
+          indicator.setAttribute('data-page-count', pageCount);
+          indicator.setAttribute('data-page-id', pageId);
+
+          indicator.setAttribute('data-bounds-x', bounds.x);
+          indicator.setAttribute('data-bounds-y', bounds.y);
+          indicator.setAttribute('data-bounds-width', bounds.width);
+          indicator.setAttribute('data-bounds-height', bounds.height);
+
+          indicator.setAttribute('data-scale', scale);
+
+          document.body.appendChild(indicator);
+        }
+
+        const {xmlDoc: rootXmlDoc} = parseInput(input);
+        const diagrams = rootXmlDoc.documentElement.getElementsByTagName('diagram');
+
+        const diagramNode = Editor.parseDiagramNode(diagrams[pageIndex]);
+        const diagramXmlDoc = diagramNode.ownerDocument;
+        const diagramId = diagrams[pageIndex].getAttribute('id');
+
+        const {bounds, scale} = renderPage(document.body, diagramXmlDoc);
+        writeResultInfo(document.body, diagrams.length, diagramId, bounds, scale);
+      }
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/export.html
+++ b/export.html
@@ -62,10 +62,9 @@
           'svg',
         ];
 
-        console.debug('Rendering page', pageIndex, 'of input', input, 'as', format);
+        console.debug('Rendering page', pageIndex, 'as', format);
 
         function initializeGraph(body) {
-          console.debug('Initialising empty document');
           document.body.innerHTML = '';
           const container = document.createElement('div');
           container.id = 'graph';
@@ -73,7 +72,6 @@
           container.style.height = '100%';
           body.appendChild(container);
 
-          console.debug('Initialising empty graph');
           const graph = new Graph(container);
           graph.setEnabled(false);
           graph.foldingEnabled = false;
@@ -82,8 +80,6 @@
         }
 
         function monkeypatchGraph(graph) {
-          console.debug('Monkey patching mxGraph to disable custom links');
-
           const graphGetLinkForCell = graph.getLinkForCell;
           graph.getLinkForCell = function(cell) {
             const link = graphGetLinkForCell.apply(this, arguments);
@@ -109,24 +105,9 @@
               }
             }
           };
-
-          // Fits the number of background pages to the graph
-          if (false /* PDF specific */) {
-            graph.view.getBackgroundPageBounds = function() {
-              var layout = this.graph.getPageLayout();
-              var page = this.graph.getPageSize();
-
-              return new mxRectangle(
-                  this.scale * (this.translate.x + layout.x * page.width),
-                  this.scale * (this.translate.y + layout.y * page.height),
-                  this.scale * layout.width * page.width,
-                  this.scale * layout.height * page.height);
-            };
-          }
         }
 
         function parseInput(input) {
-          console.debug('Parsing input')
           const doc = mxUtils.parseXml(input);
 
           const node = Editor.extractGraphModel(doc.documentElement, true);
@@ -143,8 +124,6 @@
           const codec = new mxCodec(xmlDoc);
           const model = graph.getModel();
           codec.decode(xmlDoc.documentElement, model);
-
-          console.debug('decoded graph doc into model', model);
         }
 
         function normalizeBackgroundColor(xmlDoc, format) {
@@ -165,18 +144,10 @@
 
         function scaleGraph(graph) {
           const bounds = graph.getGraphBounds();
-          const pageWidth = 800
-          let scale;
+          let scale = 1;
 
-          if (bounds.width < pageWidth & bounds.height < 1.5 * pageWidth) {
-            scale = 4;
-          } else if (bounds.width < 2 * pageWidth & bounds.height < 3 * pageWidth) {
-            scale = 3;
-          } else if (bounds.width < 4 * pageWidth && bounds.height < 6 * pageWidth) {
-            scale = 2;
-          }
-
-          graph.view.scaleAndTranslate(scale, Math.floor(bounds.x), Math.floor(bounds.y));
+          graph.view.scaleAndTranslate(
+              scale, -Math.floor(bounds.x), -Math.floor(bounds.y));
 
           return {bounds, scale};
         }
@@ -188,7 +159,7 @@
 
           document.body.style.backgroundColor = normalizeBackgroundColor(xmlDoc, format);
           const {bounds, scale} = scaleGraph(graph);
-          console.debug('graph reported bounds', bounds, 'and scale', scale);
+
           return {bounds, scale};
         }
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+const FORMATS = [
+];
+
+async function exportDiagram(input, pageIndex, format) {
+  input = input.toString();
+
+  switch (format) {
+    default:
+      throw new Error(`invalid format "${format}"; must be one of [${FORMATS.join(', ')}]`);
+  }
+}
+
+module.exports = exportDiagram;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,41 @@
+const path = require('path');
+
+const puppeteer = require('puppeteer');
+
+const EXPORT_URL = 'file://' + path.join(__dirname, 'export.html');
+const RESULT_INFO_SELECTOR = '#result-info';
 const FORMATS = [
 ];
+
+async function launchExporter(timeout=30000) {
+  console.debug('Launching browser via Puppeteer');
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: [
+      '--disable-gpu',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+    ],
+  });
+
+  console.debug('Preparing a new page');
+  const page = await browser.newPage();
+  page.on('console', message => console.debug('Browser:', message.text()));
+
+  console.debug('Navigating to the exporter');
+  await page.goto(EXPORT_URL, {
+    waitUntil: 'networkidle0',
+  });
+
+  console.debug(`Setting up browser timeout in ${timeout} microseconds`);
+  const browserTimeout = setTimeout(() => {
+    console.warn('Closing browser from timeout');
+    browser.close();
+  }, timeout);
+
+  return {browser, browserTimeout, page};
+}
 
 async function exportDiagram(input, pageIndex, format) {
   input = input.toString();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "index.js",
   "dependencies": {
     "arg": "^4.1.3",
-    "console-inject": "^1.0.8"
+    "console-inject": "^1.0.8",
+    "puppeteer": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,7 @@
   "author": "Luke Carrier <luke@carrier.im>",
   "main": "index.js",
   "dependencies": {
+    "arg": "^4.1.3",
+    "console-inject": "^1.0.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,23 @@
 # yarn lockfile v1
 
 
+"@types/node@*":
+  version "14.0.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.11.tgz#61d4886e2424da73b7b25547f59fdcb534c165a3"
+  integrity sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==
+
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
 arg@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -12,6 +29,20 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.0.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
+bl@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
+  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -20,10 +51,28 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
+buffer@^5.2.1, buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 callsite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
   integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 commander@~2.20.3:
   version "2.20.3"
@@ -44,12 +93,56 @@ console-inject@^1.0.8:
     handlebars "^4.0.12"
     shelljs "^0.8.3"
 
+debug@4, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
+
+extract-zip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.0.tgz#f53b71d44f4ff5a4527a2259ade000fb8b303492"
+  integrity sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-glob@^7.0.0:
+get-stream@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
+
+glob@^7.0.0, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -73,6 +166,19 @@ handlebars@^4.0.12:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -81,7 +187,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -90,6 +196,11 @@ interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+mime@^2.0.3:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
+  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -103,12 +214,22 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
+ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -125,6 +246,54 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+proxy-from-env@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+puppeteer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-3.3.0.tgz#95839af9fdc0aa4de7e5ee073a4c0adeb9e2d3d7"
+  integrity sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==
+  dependencies:
+    debug "^4.1.0"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^4.0.0"
+    mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^3.0.2"
+    tar-fs "^2.0.0"
+    unbzip2-stream "^1.3.3"
+    ws "^7.2.3"
+
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -138,6 +307,18 @@ resolve@^1.1.6:
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 shelljs@^0.8.3:
   version "0.8.4"
@@ -153,12 +334,58 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+tar-fs@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.0.tgz#d1cdd121ab465ee0eb9ccde2d35049d3f3daf0d5"
+  integrity sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.0.0"
+
+tar-stream@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
+  integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
+  dependencies:
+    bl "^4.0.1"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
+through@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 uglify-js@^3.1.4:
   version "3.9.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.4.tgz#867402377e043c1fc7b102253a22b64e5862401b"
   integrity sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==
   dependencies:
     commander "~2.20.3"
+
+unbzip2-stream@^1.3.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 wordwrap@^1.0.0:
   version "1.0.0"
@@ -169,3 +396,16 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@^7.2.3:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,170 @@
 # yarn lockfile v1
 
 
+arg@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
+commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+console-inject@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/console-inject/-/console-inject-1.0.8.tgz#9160efa5424eca2215ffab187a54be7ab54f525e"
+  integrity sha512-O3koUPbT1VE2h6dmnJiopgbraajw9oqe42EGENqe0W1zvuQ06rilpDWPxsybMbAhm5bNlunzJ8Xg0Z/LbL4lhg==
+  dependencies:
+    callsite "^1.0.0"
+    handlebars "^4.0.12"
+    shelljs "^0.8.3"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+glob@^7.0.0:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+handlebars@^4.0.12:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+neo-async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
+resolve@^1.1.6:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
+shelljs@^0.8.3:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+uglify-js@^3.1.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.4.tgz#867402377e043c1fc7b102253a22b64e5862401b"
+  integrity sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==
+  dependencies:
+    commander "~2.20.3"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=


### PR DESCRIPTION
This code isn't perfect, but it's a fair bit tidier than the live JGraph implementation and I think it'll make a great base for future work.

These bugs/missing features need to be addressed before merging:

- [x] :mosquito: We can end up with -0.5px X and Y viewport bounds, for some reason?

I'm raising tickets for all of these:

- [x] Auto-scaling isn't implemented, and we've fixed the scale factor at `1`:
    - [x] :mag: Setting the scale factor is not implemented (#7).
    - [x] :left_right_arrow: It's not possible to set the target page width (#5 and #6).
- [x] Support for all of the "extras" options supported by the upstream exporter is ommitted (#15).
- [x] MathJax rendering isn't implemented yet (#16).
- [x] There's no support for background images (#17).
- [x] Loading external fonts hasn't been implemented (#18).
- [x] It's not possible to render the grid (#19).
- [x] Images can't be downloaded (#20).
- [x] There's no support for borders (#21).

